### PR TITLE
Change Flatpak runtime extension to version 1.4

### DIFF
--- a/debian/mali-t76x-corelibs.tmpfile
+++ b/debian/mali-t76x-corelibs.tmpfile
@@ -1,3 +1,3 @@
 D /run/flatpak/extension/org.freedesktop.Platform.GL.host/arm 0755 - - -
-L /run/flatpak/extension/org.freedesktop.Platform.GL.host/arm/1.6 - - - - /usr/lib/mali-t76x/arm-linux-gnueabihf/flatpak
+L /run/flatpak/extension/org.freedesktop.Platform.GL.host/arm/1.4 - - - - /usr/lib/mali-t76x/arm-linux-gnueabihf/flatpak
 L /var/lib/flatpak/extension - - - - /run/flatpak/extension


### PR DESCRIPTION
Export the EGL/GLES drivers as a Flatpak extension with version 1.4, so it
will be used by both 1.6 and 18.08 versions of the freedesktop.org runtimes.
The 1.4 version is very old and has been repurposed upstream to mean the
drivers are statically linked and free of any versioned runtime dependencies.

https://phabricator.endlessm.com/T24544